### PR TITLE
Reduce running time by using vec.splice

### DIFF
--- a/src/bin/day05.rs
+++ b/src/bin/day05.rs
@@ -62,8 +62,7 @@ fn react(mut p_vec: Vec<char>) -> Vec<char> {
             previous_c = p_vec[c - 1];
             if do_these_two_chars_cancel(p_vec[c], previous_c) {
                 // found a pair. let's remove them
-                p_vec.remove(c);
-                p_vec.remove(c - 1);
+                p_vec.splice(c - 1..c, vec![]);
                 p_vec_len -= 2;
                 this_pass_has_had_at_least_one_reaction = true;
             } else {


### PR DESCRIPTION
By replacing two `vec.remove` calls with a single `vec.splice` call, we
can cut running time by over 50% (from 2.24 sec to 0.98 sec, according
to hyperfine).  I believe the improvement is greater because it is
inside the inner loop and thus performed very frequently.